### PR TITLE
Changed comparison to use NSNumericSearch

### DIFF
--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -56,12 +56,12 @@
 
                     NSString *currentAppStoreVersion = [versionsInAppStore objectAtIndex:0];
 
-	                if ([kHarpyCurrentVersion compare:currentAppStoreVersion options:NSNumericSearch] == NSOrderedAscending) {
+                    if ([kHarpyCurrentVersion compare:currentAppStoreVersion options:NSNumericSearch] == NSOrderedAscending) {
 		                
                         [Harpy showAlertWithAppStoreVersion:currentAppStoreVersion];
 	                
                     }
-	                else {
+                    else {
 		            
                         // Current installed version is the newest public version or newer	
 	                


### PR DESCRIPTION
As proposed in https://github.com/ArtSabintsev/Harpy/issues/4 the comparison now uses NSNumericSearch. The reviewer should never see the dialog, since the version to be reviewed has a higher version number.
