### PR TITLE
Added property to set the template used to build the lookup URL.

### DIFF
--- a/Harpy/Harpy.h
+++ b/Harpy/Harpy.h
@@ -45,6 +45,8 @@ typedef NS_ENUM(NSUInteger, HarpyAlertType)
  */
 @property (assign, nonatomic) HarpyAlertType alertType;
 
+@property (copy, nonatomic) NSString *storeStringTemplate;
+
 /**
  The shared Harpy instance.
  */

--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -45,6 +45,7 @@
     self = [super init];
     if (self) {
         _alertType = HarpyAlertTypeOption;
+        self.storeStringTemplate = @"http://itunes.apple.com/lookup?id=%@";
     }
     return self;
 }
@@ -53,7 +54,7 @@
 - (void)checkVersion
 {
     // Asynchronously query iTunes AppStore for publically available version
-    NSString *storeString = [NSString stringWithFormat:@"http://itunes.apple.com/lookup?id=%@", self.appID];
+    NSString *storeString = [NSString stringWithFormat:self.storeStringTemplate, self.appID];
     NSURL *storeURL = [NSURL URLWithString:storeString];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:storeURL];
     [request setHTTPMethod:@"GET"];


### PR DESCRIPTION
I'm not sure if this is the best approach, but the lookup comes up empty if the app is not available in the US Store.
# Commit Message

In order to allow querying for apps that may not be available on the US
Store. For example, the base string for lookup for Dutch-only apps is
"http://itunes.apple.com/nl/lookup?id=%@".
