### PR TITLE
Adds a new optional parameter to set the app name 

### DIFF
--- a/Harpy/Harpy.h
+++ b/Harpy/Harpy.h
@@ -39,6 +39,11 @@ typedef NS_ENUM(NSUInteger, HarpyAlertType)
 @property (strong, nonatomic) NSString *appID;
 
 /**
+ (OPTIONAL) An optional name for the app that is displayed in the alert
+ */
+@property (strong, nonatomic) NSString *appName;
+
+/**
  (OPTIONAL) The alert type to present to the user when there is an update. See the `HarpyAlertType` enum above.
  */
 @property (assign, nonatomic) HarpyAlertType alertType;

--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -198,7 +198,13 @@
 - (void)showAlertWithAppStoreVersion:(NSString *)currentAppStoreVersion
 {
     // Reference App's name
-    NSString *appName = [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString*)kCFBundleNameKey];
+	NSString *appName;
+	if ( self.appName && ![self.appName isEqualToString:@""] ) {
+		appName = self.appName;
+	} else {
+		appName = [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString*)kCFBundleNameKey];
+	}
+    
     
     switch ( self.alertType ) {
             

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@
 	// Set the App ID for your app
 	[[Harpy sharedInstance] setAppID:@"<app_id>"];
 	
+	/* (Optional) Set an alternative name for your app
+	 This might be useful if the bundle is just an abreviation for example.
+	 By default, the application bundle name will be used. */
+	[[Harpy sharedInstance] setAppName:@"<app_name>"];
+	
 	/* (Optional) Set the Alert Type for your app 
 	 By default, the Singleton is initialized to HarpyAlertTypeOption */
 	[[Harpy sharedInstance] setAlertType:<alert_type>];


### PR DESCRIPTION
I needed this because my bundle name was just an abbreviation of the real App name and I want to show the whole app title.

This might be useful for someone else too.
