### PR TITLE
Change NSCalendarUnitDay to NSDayCalendarUnit

### DIFF
--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -162,7 +162,7 @@
 - (NSUInteger)numberOfDaysElapsedBetweenILastVersionCheckDate
 {
     NSCalendar *currentCalendar = [NSCalendar currentCalendar];
-    NSDateComponents *components = [currentCalendar components:NSCalendarUnitDay
+    NSDateComponents *components = [currentCalendar components:NSDayCalendarUnit
                                                       fromDate:self.lastVersionCheckPerformedOnDate
                                                         toDate:[NSDate date]
                                                        options:0];


### PR DESCRIPTION
This should be a fix for issue #36 which prevented submission to CocoaPods. 

See here: https://travis-ci.org/CocoaPods/Specs/builds/12498782#L155

It looks like it might be a better option to use `NSDayCalendarUnit` instead of `NSCalendarUnitDay` even though the former is deprecated.
