### PR TITLE
Now supports different AlertTypes for major, minor and patch updates.

### DIFF
--- a/Harpy/Harpy.h
+++ b/Harpy/Harpy.h
@@ -65,6 +65,22 @@ typedef NS_ENUM(NSUInteger, HarpyAlertType)
 @property (assign, nonatomic) HarpyAlertType alertType;
 
 /**
+ @b OPTIONAL: The alert type to present to the user when there is a patch update (e.g. version 2.1.3). See the @c HarpyAlertType enum above.
+ */
+@property (assign, nonatomic) HarpyAlertType patchUpdateAlertType;
+
+/**
+ @b OPTIONAL: The alert type to present to the user when there is a minor update (e.g. version 2.1.0). See the @c HarpyAlertType enum above.
+ */
+@property (assign, nonatomic) HarpyAlertType minorUpdateAlertType;
+
+/**
+ @b OPTIONAL: The alert type to present to the user when there is a major update (e.g. version 2.0). See the @c HarpyAlertType enum above.
+ */
+@property (assign, nonatomic) HarpyAlertType majorUpdateAlertType;
+
+
+/**
  @b OPTIONAL: If your application is not availabe in the U.S. Store, you must specify the two-letter
  country code for the region in which your applicaiton is available in.
  */

--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -69,7 +69,9 @@ NSString * const HarpyLanguageSpanish = @"es";
 {
     self = [super init];
     if (self) {
-        _alertType = HarpyAlertTypeOption;
+        _patchUpdateAlertType = HarpyAlertTypeSkip;
+        _minorUpdateAlertType = HarpyAlertTypeOption;
+        _majorUpdateAlertType = HarpyAlertTypeForce;
         _lastVersionCheckPerformedOnDate = [[NSUserDefaults standardUserDefaults] objectForKey:HARPY_DEFAULT_STORED_VERSION_CHECK_DATE];
     }
     return self;
@@ -233,6 +235,24 @@ NSString * const HarpyLanguageSpanish = @"es";
         skipButtonText = HARPY_LOCALIZED_STRING(@"Skip this version");
     }
     
+    // Check what version the update is, major, minor or a patch
+    NSArray *versionChunks = [currentAppStoreVersion componentsSeparatedByString: @"."];
+
+    if ([versionChunks count] == 3 && ![versionChunks[2] isEqualToString:@"0"]) {
+        [self setAlertType:[self patchUpdateAlertType]]; // 2.3.4
+    }
+    else if ([versionChunks count] == 3 && [versionChunks[2] isEqualToString:@"0"]){
+        if ([versionChunks[1] isEqualToString:@"0"]) {
+            [self setAlertType:[self majorUpdateAlertType]]; //2.3.0
+        }
+        else {
+            [self setAlertType:[self minorUpdateAlertType]]; //2.0.0
+        }
+    }
+    else {
+        [self setAlertType:[self majorUpdateAlertType]]; //2.0
+    }
+
     // Initialize UIAlertView
     UIAlertView *alertView;
     


### PR DESCRIPTION
I created support for different AlertTypes for different updates. These are the default options, and can be changed using the following.
    `[[Harpy sharedInstance] setMajorUpdateAlertType:HarpyAlertTypeOption];`
   `[[Harpy sharedInstance] setMinorUpdateAlertType:HarpyAlertTypeForce];`
    `[[Harpy sharedInstance] setPatchUpdateAlertType:HarpyAlertTypeOption];`

(e.g. Major=2.0, Minor=2.1, Patch=2.1.1)
