### PR TITLE
Introduce AlertTypeNone, enableDebug and forceAlert

### DIFF
--- a/Harpy/Harpy.h
+++ b/Harpy/Harpy.h
@@ -38,7 +38,8 @@ typedef NS_ENUM(NSUInteger, HarpyAlertType)
 {
     HarpyAlertTypeForce = 1,    // Forces user to update your app
     HarpyAlertTypeOption,       // (DEFAULT) Presents user with option to update app now or at next launch
-    HarpyAlertTypeSkip          // Presents User with option to update the app now, at next launch, or to skip this version all together
+    HarpyAlertTypeSkip,          // Presents User with option to update the app now, at next launch, or to skip this version all together
+    HarpyAlertTypeNone,         // Don't show the alert type , usefull for skipping Patch ,Minor, Major update
 };
 
 @interface Harpy : NSObject
@@ -58,6 +59,16 @@ typedef NS_ENUM(NSUInteger, HarpyAlertType)
  @b OPTIONAL: The preferred name for the app. This name will be displayed in the @c UIAlertView in place of the bundle name.
  */
 @property (strong, nonatomic) NSString *appName;
+
+/**
+ @b OPTIONAL: Ability to Force Alert
+ */
+@property (assign, nonatomic) BOOL forceAlert;
+
+/**
+ @b OPTIONAL: Log Debug information
+ */
+@property (assign, nonatomic) BOOL enableDebug;
 
 /**
  @b OPTIONAL: The alert type to present to the user when there is an update. See the @c HarpyAlertType enum above.

--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -90,12 +90,22 @@ NSString * const HarpyLanguageSpanish = @"es";
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:storeURL];
     [request setHTTPMethod:@"GET"];
     NSOperationQueue *queue = [[NSOperationQueue alloc] init];
+
+    if (self.enableDebug) {
+        NSLog(@"[Harpy] Requesting storeURL: %@",storeURL);
+    }
+
     
     [NSURLConnection sendAsynchronousRequest:request queue:queue completionHandler:^(NSURLResponse *response, NSData *data, NSError *error) {
         
         if ([data length] > 0 && !error) { // Success
             
             self.appData = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:nil];
+
+            if (self.enableDebug) {
+               // NSString* jsonString = [NSString stringWithUTF8String:[data bytes]];
+                NSLog(@"[Harpy] Result store JSON: %@",self.appData);
+            }
             
             dispatch_async(dispatch_get_main_queue(), ^{
                 
@@ -107,11 +117,18 @@ NSString * const HarpyLanguageSpanish = @"es";
                 // All versions that have been uploaded to the AppStore
                 NSArray *versionsInAppStore = [HARPY_APP_STORE_RESULTS valueForKey:@"version"];
                 
-                if ([versionsInAppStore count]) { // No versions of app in AppStore
+                // Force an Alert
+                if (self.forceAlert) {
+                    NSString *currentAppStoreVersion = @"FORCEDVERSION";
+                    [self showAlertWithAppStoreVersion:currentAppStoreVersion];
+
+                } else {
+                    if ([versionsInAppStore count]) { // No versions of app in AppStore
+
+                        NSString *currentAppStoreVersion = [versionsInAppStore objectAtIndex:0];
+                        [self checkIfDeviceIsSupportedInCurrentAppStoreVersion:currentAppStoreVersion];
                     
-                    NSString *currentAppStoreVersion = [versionsInAppStore objectAtIndex:0];
-                    [self checkIfDeviceIsSupportedInCurrentAppStoreVersion:currentAppStoreVersion];
-                
+                    }
                 }
             });
         }
@@ -275,6 +292,9 @@ NSString * const HarpyLanguageSpanish = @"es";
                                          otherButtonTitles:updateButtonText, nextTimeButtonText, nil];
             
         } break;
+
+        case HarpyAlertTypeNone: { // Do Nothing
+        } break;
     }
     
     [alertView show];
@@ -354,6 +374,9 @@ NSString * const HarpyLanguageSpanish = @"es";
                     [self.delegate harpyUserDidCancel];
                 }
             }
+        } break;
+
+        case HarpyAlertTypeNone: { // Do nothing
         } break;
     }
 }

--- a/README.md
+++ b/README.md
@@ -107,6 +107,13 @@ Copy the 'Harpy' folder into your Xcode project. It contains the Harpy.h and Har
 
 And you're all set!
 
+### Alert Types
+
+- HarpyAlertTypeForce = 1,    // Forces user to update your app
+- HarpyAlertTypeOption,       // (DEFAULT) Presents user with option to update app now or at next launch
+- HarpyAlertTypeSkip,          // Presents User with option to update the app now, at next launch, or to skip this version all together
+- HarpyAlertTypeNone,         // Don't show the alert type , usefull for skipping Patch ,Minor, Major update
+
 ### Differentiated Alerts for Patch, Minor, and Major Updates
 If you would like to set a different type of alert for patch, minor, and/or major updates, simply add one or all of the following *optional* lines to your setup *before* calling any of the `checkVersion` methods:
 
@@ -137,7 +144,7 @@ If you'd like to handle or track the end-user's behavior, four delegate methods 
 ### Force Localization
 There are some situations where a developer may want to the update dialog to *always* appear in a certain language, irrespective of the devices/system default language (e.g. apps released in a specific country). As of v2.5.0, this feature has been added to Harpy (see [Issue #41](https://github.com/ArtSabintsev/Harpy/issues/41)). Please set the `forceLanguageLocalization` property using the `HarpyLanugage` string constants defined in `Harpy.h` if you would like override the system's default lanuage for the Harpy alert dialogs.
 
-``` obj-c 
+``` obj-c
 [[Harpy sharedInstance] setForceLanguageLocalization<#HarpyLanguageConstant#>];
 ```
 
@@ -148,6 +155,18 @@ A new helper utility, [UIDevice+SupportedDevices](https://github.com/ArtSabintse
 
 ### Important Note on App Store Submissions
 The App Store reviewer will **not** see the alert. 
+
+### Testing and debugging info
+To enable debug information (like the iTunes query and results)
+``` obj-c
+[[Harpy sharedInstance] setEnableDebug:TRUE];
+```
+
+To force an Alert: when you are testing for an app that is not yet in the appstore f.i.
+
+``` obj-c
+[[Harpy sharedInstance] setForceAlert:TRUE];
+```
 
 ### Created and maintained by
 [Arthur Ariel Sabintsev](http://www.sabintsev.com/) 


### PR DESCRIPTION
This PR enables:
- AlertTypeNone: in our case we don't want to have an alert for Patch update only for Minor and Major
- setEnableDebug: this logs the json & URL used to connect to the iTunes store. Handy if you are tracking why it can't be find a version
- setForceAlert: sometimes you want to see the alert regardless what your app version in the appstore is. This allows you to force this. Handy if no version are in the Store yet.
