### PR TITLE
Update to ensure there is a version check

### DIFF
--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -121,7 +121,7 @@ NSString * const HarpyLanguageSpanish = @"es";
                     NSString *currentAppStoreVersion = [versionsInAppStore objectAtIndex:0];
                     if ([self isDeviceCompatible]) {
                         [self checkIfDeviceIsSupportedInCurrentAppStoreVersion:currentAppStoreVersion];
-                    } else {
+                    } else if ([HARPY_CURRENT_VERSION compare:currentAppStoreVersion options:NSNumericSearch] == NSOrderedAscending) {
                         [self showAlertIfCurrentAppStoreVersionNotSkipped:currentAppStoreVersion];
                     }
                 }


### PR DESCRIPTION
No version check was available if device types were not being checked. Thus I added one in the logic to display the alert.
