### PR TITLE
UIAlertViewDelegate change method called

### DIFF
--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -426,7 +426,7 @@ NSString * const HarpyLanguageTurkish               = @"tr";
 }
 
 #pragma mark - UIAlertViewDelegate
-- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
+- (void)alertView:(UIAlertView *)alertView didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
     switch ([self alertType]) {
             


### PR DESCRIPTION
If you want to do a complex action after having dismissed Update alert
view (like show another alert view, also a custom alert view), you
should be 100% sure the previous alert has been completely dismissed.
For that reason, call didDismissWithButtonIndex delegate method instead
of clickedButtonAtIndex method. Already tested in my project with this
complex actions that have to take place. Without this fix, I won’t be
able to se the following alert view.