### PR TITLE
Added missing Polish const in Harpy.h file

### DIFF
--- a/Harpy/Harpy.h
+++ b/Harpy/Harpy.h
@@ -20,6 +20,7 @@ FOUNDATION_EXPORT NSString * const HarpyLanguageGerman;
 FOUNDATION_EXPORT NSString * const HarpyLanguageItalian;
 FOUNDATION_EXPORT NSString * const HarpyLanguageJapanese;
 FOUNDATION_EXPORT NSString * const HarpyLanguageKorean;
+FOUNDATION_EXPORT NSString * const HarpyLanguagePolish;
 FOUNDATION_EXPORT NSString * const HarpyLanguagePortugueseBrazilian;
 FOUNDATION_EXPORT NSString * const HarpyLanguagePortuguesePortugal;
 FOUNDATION_EXPORT NSString * const HarpyLanguageRussian;


### PR DESCRIPTION
There was no Polish language constant in .h file. Fixed that.