### PR TITLE
Added two new methods:

### DIFF
--- a/Harpy/Harpy.h
+++ b/Harpy/Harpy.h
@@ -144,4 +144,15 @@ typedef NS_ENUM(NSUInteger, HarpyAlertType)
  */
 - (void)checkVersionWeekly;
 
+/**
+ Just tell if a new version is available.
+ Use the value stored in NSUserDefaults if a new one from the web is not available.
+ */
+- (BOOL)newVersionAvailable;
+
+/**
+ Launch the AppStore page for the app.
+ */
+- (void)launchAppStore;
+
 @end

--- a/Harpy/Harpy.h
+++ b/Harpy/Harpy.h
@@ -67,6 +67,11 @@ typedef NS_ENUM(NSUInteger, HarpyAlertType)
 @property (strong, nonatomic) NSString *appID;
 
 /**
+ For enterprise distribution of apps, the pList URL of your app.
+ */
+@property (strong, nonatomic) NSString *pListURL;
+
+/**
  @b OPTIONAL: The preferred name for the app. This name will be displayed in the @c UIAlertView in place of the bundle name.
  */
 @property (strong, nonatomic) NSString *appName;
@@ -145,7 +150,7 @@ typedef NS_ENUM(NSUInteger, HarpyAlertType)
 - (void)checkVersionWeekly;
 
 /**
- Just tell if a new version is available.
+ Just tell if a new version is available. 
  Use the value stored in NSUserDefaults if a new one from the web is not available.
  */
 - (BOOL)newVersionAvailable;

--- a/Harpy/Harpy.h
+++ b/Harpy/Harpy.h
@@ -67,9 +67,10 @@ typedef NS_ENUM(NSUInteger, HarpyAlertType)
 @property (strong, nonatomic) NSString *appID;
 
 /**
- For enterprise distribution of apps, the pList URL of your app.
+ For enterprise distribution of apps, the pList URL, and update URL of your app.
  */
 @property (strong, nonatomic) NSString *pListURL;
+@property (strong, nonatomic) NSString *updateURL;
 
 /**
  @b OPTIONAL: The preferred name for the app. This name will be displayed in the @c UIAlertView in place of the bundle name.
@@ -158,6 +159,6 @@ typedef NS_ENUM(NSUInteger, HarpyAlertType)
 /**
  Launch the AppStore page for the app.
  */
-- (void)launchAppStore;
+- (void)launchUpdateLocation;
 
 @end

--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -79,7 +79,7 @@ NSString * const HarpyLanguageTurkish               = @"tr";
 #pragma mark - Public
 - (void)checkVersion
 {
-    if ((_appID || _pListURL) && _presentingViewController) {
+    if ((_appID || (_pListURL && _updateURL)) && _presentingViewController) {
         if (_appID) {
             [self performAppStoreVersionCheck];
         }
@@ -372,6 +372,16 @@ NSString * const HarpyLanguageTurkish               = @"tr";
     }
 }
 
+- (void)launchUpdateLocation {
+    if (_pListURL) {
+        NSURL* url = [NSURL URLWithString:_updateURL];
+        [[UIApplication sharedApplication] openURL:url];
+    }
+    else if (_appID) {
+        [self launchAppStore];
+    }
+}
+
 - (void)launchAppStore
 {
     NSString *iTunesString = [NSString stringWithFormat:@"https://itunes.apple.com/app/id%@", [self appID]];
@@ -428,7 +438,7 @@ NSString * const HarpyLanguageTurkish               = @"tr";
     UIAlertAction *updateAlertAction = [UIAlertAction actionWithTitle:_updateButtonText
                                                                 style:UIAlertActionStyleDefault
                                                               handler:^(UIAlertAction *action) {
-                                                                  [self launchAppStore];
+                                                                  [self launchUpdateLocation];
                                                               }];
     
     return updateAlertAction;
@@ -468,13 +478,13 @@ NSString * const HarpyLanguageTurkish               = @"tr";
     switch ([self alertType]) {
             
         case HarpyAlertTypeForce: { // Launch App Store.app
-            [self launchAppStore];
+            [self launchUpdateLocation];
         } break;
             
         case HarpyAlertTypeOption: {
             
             if (buttonIndex == 1) { // Launch App Store.app
-                [self launchAppStore];
+                [self launchUpdateLocation];
             } else { // Ask user on next launch
                 if([self.delegate respondsToSelector:@selector(harpyUserDidCancel)]){
                     [self.delegate harpyUserDidCancel];
@@ -486,7 +496,7 @@ NSString * const HarpyLanguageTurkish               = @"tr";
         case HarpyAlertTypeSkip: {
             
             if (buttonIndex == 0) { // Skip current version in AppStore
-                [self launchAppStore];
+                [self launchUpdateLocation];
             } else if (buttonIndex == 1) { // Launch App Store.app
                 [[NSUserDefaults standardUserDefaults] setObject:_currentAppStoreVersion forKey:HarpyDefaultSkippedVersion];
                 [[NSUserDefaults standardUserDefaults] synchronize];

--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -11,6 +11,7 @@
 /// NSUserDefault macros to store user's preferences for HarpyAlertTypeSkip
 NSString * const HarpyDefaultSkippedVersion         = @"Harpy User Decided To Skip Version Update Boolean";
 NSString * const HarpyDefaultStoredVersionCheckDate = @"Harpy Stored Date From Last Version Check";
+NSString * const HarpyCurrentLatestAppStoreVersion  = @"Harpy Current Latest AppStore Version";
 
 /// App Store links
 NSString * const HarpyAppStoreLinkUniversal         = @"http://itunes.apple.com/lookup?id=%@";
@@ -79,9 +80,9 @@ NSString * const HarpyLanguageTurkish               = @"tr";
 - (void)checkVersion
 {
     if (!_appID || !_presentingViewController) {
-       
+        
         NSLog(@"[Harpy]: Please make sure that you have set _appID and _presentationViewController before calling checkVersion, checkVersionDaily, or checkVersionWeekly");
-    
+        
     } else {
         [self performVersionCheck];
     }
@@ -125,7 +126,7 @@ NSString * const HarpyLanguageTurkish               = @"tr";
         [self checkVersion];
     }
     
-    // If weekly condition is satisfied, perform version check 
+    // If weekly condition is satisfied, perform version check
     if ([self numberOfDaysElapsedBetweenLastVersionCheckDate] > 7) {
         [self checkVersion];
     }
@@ -146,7 +147,7 @@ NSString * const HarpyLanguageTurkish               = @"tr";
     NSURL *storeURL = [NSURL URLWithString:storeString];
     NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:storeURL];
     [request setHTTPMethod:@"GET"];
-
+    
     if ([self isDebugEnabled]) {
         NSLog(@"[Harpy] storeURL: %@", storeURL);
     }
@@ -155,29 +156,30 @@ NSString * const HarpyLanguageTurkish               = @"tr";
     NSURLSessionDataTask *task = [session dataTaskWithRequest:request
                                             completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
                                                 if ([data length] > 0 && !error) { // Success
-            
+                                                    
                                                     self.appData = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:nil];
-            
+                                                    
                                                     if ([self isDebugEnabled]) {
                                                         NSLog(@"[Harpy] JSON Results: %@", _appData);
                                                     }
-            
+                                                    
                                                     dispatch_async(dispatch_get_main_queue(), ^{
-                
+                                                        
                                                         // Store version comparison date
                                                         self.lastVersionCheckPerformedOnDate = [NSDate date];
                                                         [[NSUserDefaults standardUserDefaults] setObject:[self lastVersionCheckPerformedOnDate] forKey:HarpyDefaultStoredVersionCheckDate];
                                                         [[NSUserDefaults standardUserDefaults] synchronize];
-                
+                                                        
                                                         /**
                                                          Current version that has been uploaded to the AppStore.
                                                          Used to contain all versions, but now only contains the latest version.
                                                          Still returns an instance of NSArray.
                                                          */
                                                         NSArray *versionsInAppStore = [[self.appData valueForKey:@"results"] valueForKey:@"version"];
-                
+                                                        
                                                         if ([versionsInAppStore count]) {
                                                             _currentAppStoreVersion = [versionsInAppStore objectAtIndex:0];
+                                                            [[NSUserDefaults standardUserDefaults] setObject:_currentAppStoreVersion forKey:HarpyCurrentLatestAppStoreVersion];
                                                             [self checkIfAppStoreVersionIsNewestVersion:_currentAppStoreVersion];
                                                         }
                                                     });
@@ -217,6 +219,13 @@ NSString * const HarpyLanguageTurkish               = @"tr";
         // Don't show alert.
         return;
     }
+}
+
+- (BOOL)newVersionAvailable {
+    if (!_currentAppStoreVersion) {
+        _currentAppStoreVersion = [[NSUserDefaults standardUserDefaults] objectForKey:HarpyCurrentLatestAppStoreVersion];
+    }
+    return [[self currentVersion] compare:_currentAppStoreVersion options:NSNumericSearch] == NSOrderedAscending;
 }
 
 - (void)localizeAlertStringsForCurrentAppStoreVersion:(NSString *)currentAppStoreVersion
@@ -304,7 +313,7 @@ NSString * const HarpyLanguageTurkish               = @"tr";
         case HarpyAlertTypeSkip: {
             
             if (currentOSVersion > 7) {
-            
+                
                 [alertController addAction:[self skipAlertAction]];
                 [alertController addAction:[self nextTimeAlertAction]];
                 [alertController addAction:[self updateAlertAction]];
@@ -313,7 +322,7 @@ NSString * const HarpyLanguageTurkish               = @"tr";
                     [_presentingViewController presentViewController:alertController animated:YES completion:nil];
                 }
                 
-
+                
             } else {
                 
                 alertView = [[UIAlertView alloc] initWithTitle:_updateAvailableMessage
@@ -324,13 +333,13 @@ NSString * const HarpyLanguageTurkish               = @"tr";
             }
             
         } break;
-
+            
         case HarpyAlertTypeNone: { // Do Nothing
         } break;
     }
     
     [alertView show];
-
+    
     if([self.delegate respondsToSelector:@selector(harpyDidShowUpdateDialog)]){
         [self.delegate harpyDidShowUpdateDialog];
     }
@@ -341,7 +350,7 @@ NSString * const HarpyLanguageTurkish               = @"tr";
     NSString *iTunesString = [NSString stringWithFormat:@"https://itunes.apple.com/app/id%@", [self appID]];
     NSURL *iTunesURL = [NSURL URLWithString:iTunesString];
     [[UIApplication sharedApplication] openURL:iTunesURL];
-
+    
     if([self.delegate respondsToSelector:@selector(harpyUserDidLaunchAppStore)]){
         [self.delegate harpyUserDidLaunchAppStore];
     }
@@ -359,7 +368,7 @@ NSString * const HarpyLanguageTurkish               = @"tr";
         } else if ([newVersionComponents[1] integerValue] > [oldVersionComponents[1] integerValue]) { // a.B.c
             if (_minorUpdateAlertType) _alertType = _minorUpdateAlertType;
         } else if ([newVersionComponents[2] integerValue] > [oldVersionComponents[2] integerValue]) { // a.b.C
-           if (_patchUpdateAlertType) _alertType = _patchUpdateAlertType;
+            if (_patchUpdateAlertType) _alertType = _patchUpdateAlertType;
         }
     }
 }
@@ -463,7 +472,7 @@ NSString * const HarpyLanguageTurkish               = @"tr";
                 }
             }
         } break;
-
+            
         case HarpyAlertTypeNone: {
             // Do nothing
         } break;


### PR DESCRIPTION
I wanted a persistent message that tells users if a newer version is available. For example, in the Settings page of my app, I show the current version of the app. I wanted to show if a newer version is available, and if yes, have a non-modal option to go to the AppStore. Something like the image below.

![ios simulator screen shot may 24 2015 9 54 30 pm](https://cloud.githubusercontent.com/assets/216346/7792051/3958102e-0260-11e5-8efb-7ef1b7178a41.png)

Current implementation of Harpy didn't allow me that. Hence I added two new methods. Maybe others will find them useful too?

1. [[Harpy sharedInstance] newVersionAvailable] - Returns YES/NO boolean value to tell if a new version is available. Uses a stored value from NSUserDefaults.
2. [[Harpy sharedInstance] launchAppStore] - Launches the AppStore for the app.

