### PR TITLE
fixed: crash because of NSArray out of range

### DIFF
--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -334,22 +334,26 @@ NSString * const HarpyLanguageTurkish               = @"tr";
 
 - (void)alertTypeForVersion:(NSString *)currentAppStoreVersion
 {
+    NSInteger const maxCount = 4;
+    NSInteger v0[maxCount] = {0}, v1[maxCount] = {0}; // old and new version Numbers
+    NSInteger alertType[maxCount] = {self.majorUpdateAlertType, self.minorUpdateAlertType, self.patchUpdateAlertType, self.revisionUpdateAlertType};
+
     // Check what version the update is, major, minor or a patch
-    NSArray *oldVersionComponents = [[self currentVersion] componentsSeparatedByString:@"."];
-    NSArray *newVersionComponents = [currentAppStoreVersion componentsSeparatedByString: @"."];
+    NSArray<NSString *> *oldVersionComponents = [self.currentVersion componentsSeparatedByString:@"."];
+    NSArray<NSString *> *newVersionComponents = [currentAppStoreVersion componentsSeparatedByString:@"."];
+    for (NSInteger i = 0; i < maxCount; ++i) {
+        v0[i] = (i < oldVersionComponents.count) ? oldVersionComponents[i].integerValue : 0; // add 0 if insufficient，不足则补0
+    }
+    for (NSInteger i = 0; i < maxCount; ++i) {
+        v1[i] = (i < newVersionComponents.count) ? newVersionComponents[i].integerValue : 0; // add 0 if insufficient，不足则补0
+    }
 
-    BOOL oldVersionComponentIsProperFormat = (2 <= [oldVersionComponents count] && [oldVersionComponents count] <= 4);
-    BOOL newVersionComponentIsProperFormat = (2 <= [newVersionComponents count] && [newVersionComponents count] <= 4);
-
-    if (oldVersionComponentIsProperFormat && newVersionComponentIsProperFormat) {
-        if ([newVersionComponents[0] integerValue] > [oldVersionComponents[0] integerValue]) { // A.b.c.d
-            if (_majorUpdateAlertType) _alertType = _majorUpdateAlertType;
-        } else if ([newVersionComponents[1] integerValue] > [oldVersionComponents[1] integerValue]) { // a.B.c.d
-            if (_minorUpdateAlertType) _alertType = _minorUpdateAlertType;
-        } else if ((newVersionComponents.count > 2) && (oldVersionComponents.count <= 2 || ([newVersionComponents[2] integerValue] > [oldVersionComponents[2] integerValue]))) { // a.b.C.d
-            if (_patchUpdateAlertType) _alertType = _patchUpdateAlertType;
-        } else if ((newVersionComponents.count > 3) && (oldVersionComponents.count <= 3 || ([newVersionComponents[3] integerValue] > [oldVersionComponents[3] integerValue]))) { // a.b.c.D
-            if (_revisionUpdateAlertType) _alertType = _revisionUpdateAlertType;
+    for (NSInteger i = 0; i < maxCount; ++i) { // ignore numbers after the maxCount-th number
+        if (v1[i] > v0[i]) {
+            if (0 != alertType[i]) {
+                self.alertType = alertType[i];
+            }
+            break;
         }
     }
 }

--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -341,14 +341,9 @@ NSString * const HarpyLanguageTurkish               = @"tr";
     // Check what version the update is, major, minor or a patch
     NSArray<NSString *> *oldVersionComponents = [self.currentVersion componentsSeparatedByString:@"."];
     NSArray<NSString *> *newVersionComponents = [currentAppStoreVersion componentsSeparatedByString:@"."];
-    for (NSInteger i = 0; i < maxCount; ++i) {
+    for (NSInteger i = 0; i < maxCount; ++i) {  // ignore numbers after the maxCount-th number
         v0[i] = (i < oldVersionComponents.count) ? oldVersionComponents[i].integerValue : 0; // add 0 if insufficient，不足则补0
-    }
-    for (NSInteger i = 0; i < maxCount; ++i) {
         v1[i] = (i < newVersionComponents.count) ? newVersionComponents[i].integerValue : 0; // add 0 if insufficient，不足则补0
-    }
-
-    for (NSInteger i = 0; i < maxCount; ++i) { // ignore numbers after the maxCount-th number
         if (v1[i] > v0[i]) {
             if (0 != alertType[i]) {
                 self.alertType = alertType[i];


### PR DESCRIPTION
When the old short version string is shorter than the new one. Such as, the old version is 1.4 and the new one is 1.5.1