### PR TITLE
(more flexible solution) fixed: crash because of NSArray out of range

### DIFF
--- a/Harpy/Harpy.h
+++ b/Harpy/Harpy.h
@@ -81,6 +81,12 @@ typedef NS_ENUM(NSUInteger, HarpyAlertType)
 @property (strong, nonatomic) NSString *appName;
 
 /**
+ @b OPTIONAL: You can provide another version for the app before update, if you need a version like 1.2.3.4, which is not allowed by the App Store.
+ Otherwise, it will be read with the key "CFBundleShortVersionString" from the app's Info.plist.
+ */
+@property (strong, nonatomic) NSString *appVersion;
+
+/**
  @b OPTIONAL: Log Debug information
  */
 @property (assign, nonatomic, getter=isDebugEnabled) BOOL debugEnabled;

--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -206,7 +206,7 @@ NSString * const HarpyLanguageTurkish               = @"tr";
 - (void)checkIfAppStoreVersionIsNewestVersion:(NSString *)currentAppStoreVersion
 {
     // Current installed version is the newest public version or newer (e.g., dev version)
-    if ([[self currentVersion] compare:currentAppStoreVersion options:NSNumericSearch] == NSOrderedAscending) {
+    if ([self.appVersion compare:currentAppStoreVersion options:NSNumericSearch] == NSOrderedAscending) {
         [self localizeAlertStringsForCurrentAppStoreVersion:currentAppStoreVersion];
         [self alertTypeForVersion:currentAppStoreVersion];
         [self showAlertIfCurrentAppStoreVersionNotSkipped:currentAppStoreVersion];
@@ -339,7 +339,7 @@ NSString * const HarpyLanguageTurkish               = @"tr";
     NSInteger alertType[maxCount] = {self.majorUpdateAlertType, self.minorUpdateAlertType, self.patchUpdateAlertType, self.revisionUpdateAlertType};
 
     // Check what version the update is, major, minor or a patch
-    NSArray<NSString *> *oldVersionComponents = [self.currentVersion componentsSeparatedByString:@"."];
+    NSArray<NSString *> *oldVersionComponents = [self.appVersion componentsSeparatedByString:@"."];
     NSArray<NSString *> *newVersionComponents = [currentAppStoreVersion componentsSeparatedByString:@"."];
     for (NSInteger i = 0; i < maxCount; ++i) {  // ignore numbers after the maxCount-th number
         v0[i] = (i < oldVersionComponents.count) ? oldVersionComponents[i].integerValue : 0; // add 0 if insufficient，不足则补0
@@ -354,9 +354,11 @@ NSString * const HarpyLanguageTurkish               = @"tr";
 }
 
 #pragma mark - NSBundle Strings
-- (NSString *)currentVersion
-{
-    return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+- (NSString *)appVersion {
+    if (_appVersion == nil) {
+        _appVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+    }
+    return _appVersion;
 }
 
 - (NSString *)bundlePath

--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -334,22 +334,21 @@ NSString * const HarpyLanguageTurkish               = @"tr";
 
 - (void)alertTypeForVersion:(NSString *)currentAppStoreVersion
 {
+    NSInteger const maxCount = 4;
+    NSInteger v0[maxCount] = {0}, v1[maxCount] = {0}; // old and new version Numbers
+    NSInteger alertType[maxCount] = {self.majorUpdateAlertType, self.minorUpdateAlertType, self.patchUpdateAlertType, self.revisionUpdateAlertType};
+
     // Check what version the update is, major, minor or a patch
-    NSArray *oldVersionComponents = [[self currentVersion] componentsSeparatedByString:@"."];
-    NSArray *newVersionComponents = [currentAppStoreVersion componentsSeparatedByString: @"."];
-
-    BOOL oldVersionComponentIsProperFormat = (2 <= [oldVersionComponents count] && [oldVersionComponents count] <= 4);
-    BOOL newVersionComponentIsProperFormat = (2 <= [newVersionComponents count] && [newVersionComponents count] <= 4);
-
-    if (oldVersionComponentIsProperFormat && newVersionComponentIsProperFormat) {
-        if ([newVersionComponents[0] integerValue] > [oldVersionComponents[0] integerValue]) { // A.b.c.d
-            if (_majorUpdateAlertType) _alertType = _majorUpdateAlertType;
-        } else if ([newVersionComponents[1] integerValue] > [oldVersionComponents[1] integerValue]) { // a.B.c.d
-            if (_minorUpdateAlertType) _alertType = _minorUpdateAlertType;
-        } else if ((newVersionComponents.count > 2) && (oldVersionComponents.count <= 2 || ([newVersionComponents[2] integerValue] > [oldVersionComponents[2] integerValue]))) { // a.b.C.d
-            if (_patchUpdateAlertType) _alertType = _patchUpdateAlertType;
-        } else if ((newVersionComponents.count > 3) && (oldVersionComponents.count <= 3 || ([newVersionComponents[3] integerValue] > [oldVersionComponents[3] integerValue]))) { // a.b.c.D
-            if (_revisionUpdateAlertType) _alertType = _revisionUpdateAlertType;
+    NSArray<NSString *> *oldVersionComponents = [self.currentVersion componentsSeparatedByString:@"."];
+    NSArray<NSString *> *newVersionComponents = [currentAppStoreVersion componentsSeparatedByString:@"."];
+    for (NSInteger i = 0; i < maxCount; ++i) {  // ignore numbers after the maxCount-th number
+        v0[i] = (i < oldVersionComponents.count) ? oldVersionComponents[i].integerValue : 0; // add 0 if insufficient，不足则补0
+        v1[i] = (i < newVersionComponents.count) ? newVersionComponents[i].integerValue : 0; // add 0 if insufficient，不足则补0
+        if (v1[i] > v0[i]) {
+            if (0 != alertType[i]) {
+                self.alertType = alertType[i];
+            }
+            break;
         }
     }
 }


### PR DESCRIPTION
When the old short version string is shorter than the new one. Such as,
the old version is 1.4 and the new one is 1.5.1