### PR TITLE
Fixed localization in case Harpy linked as Framework (using cocoapods)

### DIFF
--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -362,12 +362,12 @@ NSString * const HarpyLanguageTurkish               = @"tr";
 
 - (NSString *)bundlePath
 {
-    return [[NSBundle mainBundle] pathForResource:@"Harpy" ofType:@"bundle"];
+    return [[NSBundle bundleForClass:[self class]] pathForResource:@"Harpy" ofType:@"bundle"];
 }
 
 - (NSString *)localizedStringForKey:(NSString *)stringKey
 {
-    return ([[NSBundle mainBundle] pathForResource:@"Harpy" ofType:@"bundle"] ? [[NSBundle bundleWithPath:[self bundlePath]] localizedStringForKey:stringKey value:stringKey table:@"HarpyLocalizable"] : stringKey);
+    return ([[NSBundle bundleForClass:[self class]] pathForResource:@"Harpy" ofType:@"bundle"] ? [[NSBundle bundleWithPath:[self bundlePath]] localizedStringForKey:stringKey value:stringKey table:@"HarpyLocalizable"] : stringKey);
 }
 
 - (NSString *)forcedLocalizedStringForKey:(NSString *)stringKey


### PR DESCRIPTION
Current version doesn't find Harpy bundle in case it is linked as Framework.