### PR TITLE
Fixed warnings that come up when opening AppStore link

### DIFF
--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -263,7 +263,9 @@ NSString * const HarpyLanguageTurkish               = @"tr";
 - (void)launchAppStore {
     NSString *iTunesString = [NSString stringWithFormat:@"https://itunes.apple.com/app/id%@", [self appID]];
     NSURL *iTunesURL = [NSURL URLWithString:iTunesString];
-    [[UIApplication sharedApplication] openURL:iTunesURL];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[UIApplication sharedApplication] openURL:iTunesURL];
+    });
 
     if ([self.delegate respondsToSelector:@selector(harpyUserDidLaunchAppStore)]){
         [self.delegate harpyUserDidLaunchAppStore];


### PR DESCRIPTION
Pressing the 'Update' button that opens up AppStore shows these warnings:

```
_BSMachError: (os/kern) invalid capability (20)
_BSMachError: (os/kern) invalid name (15)
```

This simple fix makes sure alert action is handled on main thread which in return doesn't show any warnings. Relevant stackoverflow answer: http://stackoverflow.com/a/33639650/2734193