### PR TITLE
Add Delay on Presenting Prompt by Default

### DIFF
--- a/Harpy.podspec
+++ b/Harpy.podspec
@@ -1,6 +1,6 @@
  Pod::Spec.new do |s|
   s.name         = "Harpy"
-  s.version      = "4.0.11"
+  s.version      = "4.1.0"
   s.summary      = "Notify users that a new version of your iOS app is available, and prompt them with the App Store link."
   s.homepage     = "https://github.com/ArtSabintsev/Harpy"
   s.platform     = :ios, '8.0'

--- a/Harpy/Harpy.h
+++ b/Harpy/Harpy.h
@@ -142,7 +142,7 @@ typedef NS_ENUM(NSUInteger, HarpyAlertType)
 @property (nonatomic, strong) UIColor *alertControllerTintColor;
 
 /**
- @b OPTIONAL: The tintColor for the alertController
+ @b OPTIONAL: Delays the update prompt by a specific number of days. By default, this value is set to 1 day to avoid an issue where Apple updates the JSON faster than the app binary propogates to the App Store.
  */
 @property (nonatomic, assign) NSUInteger showAlertAfterCurrentVersionHasBeenReleasedForDays;
 

--- a/Harpy/Harpy.h
+++ b/Harpy/Harpy.h
@@ -141,6 +141,11 @@ typedef NS_ENUM(NSUInteger, HarpyAlertType)
  */
 @property (nonatomic, strong) UIColor *alertControllerTintColor;
 
+/**
+ @b OPTIONAL: The tintColor for the alertController
+ */
+@property (nonatomic, assign) NSUInteger showAlertAfterCurrentVersionHasBeenReleasedForDays;
+
 #pragma mark - Methods
 
 /**

--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -178,12 +178,22 @@ NSString * const HarpyLanguageVietnamese            = @"vi";
 
             NSDictionary<NSString *, id> *results = [self.appData valueForKey:@"results"];
 
+            /**
+             Checks to see when the latest version of the app was released.
+             If the release date is greater-than-or-equal-to `_showAlertAfterCurrentVersionHasBeenReleasedForDays`,
+             the user will prompted to update their app (if the version is newer - checked later on in this method).
+             */
+
             NSString *releaseDateString = [[results valueForKey:@"currentVersionReleaseDate"] objectAtIndex:0];
-            NSInteger daysSinceRelease = [self daysSinceDateString:releaseDateString];
-            if (!(daysSinceRelease >= _showAlertAfterCurrentVersionHasBeenReleasedForDays)) {
-                NSString *message = [NSString stringWithFormat:@"Your app has been released for %ld days, but Siren cannot prompt the user until %lu days have passed.", (long)daysSinceRelease, (unsigned long)_showAlertAfterCurrentVersionHasBeenReleasedForDays];
-                [self printDebugMessage:message];
+            if (releaseDateString == nil) {
                 return;
+            } else {
+                NSInteger daysSinceRelease = [self daysSinceDateString:releaseDateString];
+                if (!(daysSinceRelease >= _showAlertAfterCurrentVersionHasBeenReleasedForDays)) {
+                    NSString *message = [NSString stringWithFormat:@"Your app has been released for %ld days, but Siren cannot prompt the user until %lu days have passed.", (long)daysSinceRelease, (unsigned long)_showAlertAfterCurrentVersionHasBeenReleasedForDays];
+                    [self printDebugMessage:message];
+                    return;
+                }
             }
 
             /**
@@ -191,19 +201,23 @@ NSString * const HarpyLanguageVietnamese            = @"vi";
              Used to contain all versions, but now only contains the latest version.
              Still returns an instance of NSArray.
              */
-            NSArray *versionsInAppStore = [results valueForKey:@"version"];
 
-            if ([versionsInAppStore count]) {
-                _currentAppStoreVersion = [versionsInAppStore objectAtIndex:0];
-                if ([self isAppStoreVersionNewer:_currentAppStoreVersion]) {
-                    [self appStoreVersionIsNewer:_currentAppStoreVersion];
-                } else {
-                    [self printDebugMessage:@"Currently installed version is newer."];
+            NSArray *versionsInAppStore = [results valueForKey:@"version"];
+            if (versionsInAppStore == nil) {
+                return;
+            } else {
+                if ([versionsInAppStore count]) {
+                    _currentAppStoreVersion = [versionsInAppStore objectAtIndex:0];
+                    if ([self isAppStoreVersionNewer:_currentAppStoreVersion]) {
+                        [self appStoreVersionIsNewer:_currentAppStoreVersion];
+                    } else {
+                        [self printDebugMessage:@"Currently installed version is newer."];
+                    }
                 }
             }
         });
     } else {
-        [self printDebugMessage:@"Device is incompatible with installed verison of iOS"];
+        [self printDebugMessage:@"Device is incompatible with installed verison of iOS."];
     }
 }
 

--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -178,8 +178,13 @@ NSString * const HarpyLanguageVietnamese            = @"vi";
 
             NSDictionary<NSString *, id> *results = [self.appData valueForKey:@"results"];
 
-            NSString *releaseDate = [results valueForKey:@"currentVersionReleaseDate"];
-            
+            NSString *releaseDateString = [[results valueForKey:@"currentVersionReleaseDate"] objectAtIndex:0];
+            NSInteger daysSinceRelease = [self daysSinceDateString:releaseDateString];
+            if (!(daysSinceRelease >= _showAlertAfterCurrentVersionHasBeenReleasedForDays)) {
+                NSString *message = [NSString stringWithFormat:@"Your app has been released for %ld days, but Siren cannot prompt the user until %lu days have passed.", (long)daysSinceRelease, (unsigned long)_showAlertAfterCurrentVersionHasBeenReleasedForDays];
+                [self printDebugMessage:message];
+                return;
+            }
 
             /**
              Current version that has been uploaded to the AppStore.
@@ -407,7 +412,7 @@ NSString * const HarpyLanguageVietnamese            = @"vi";
     }
 }
 
-#pragma mark - NSBundle Strings
+#pragma mark - NSBundle
 
 - (NSString *)bundleID {
     return [NSBundle mainBundle].bundleIdentifier;
@@ -424,6 +429,22 @@ NSString * const HarpyLanguageVietnamese            = @"vi";
 - (NSString *)forcedLocalizedStringForKey:(NSString *)stringKey {
     NSString *path = [[NSBundle bundleWithPath:[self bundlePath]] pathForResource:[self forceLanguageLocalization] ofType:@"lproj"];
     return [[NSBundle bundleWithPath:path] localizedStringForKey:stringKey value:stringKey table:@"HarpyLocalizable"];
+}
+
+#pragma mark - NSDate
+
+- (NSInteger)daysSinceDate:(NSDate *)date {
+    NSCalendar *calendar = NSCalendar.currentCalendar;
+    NSDateComponents *components = [calendar components:NSCalendarUnitDay fromDate:date toDate:[NSDate new] options:0];
+    return components.day;
+}
+
+- (NSInteger)daysSinceDateString:(NSString *)dateString {
+    NSDateFormatter *dateFormatter = [NSDateFormatter new];
+    dateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss'Z'";
+    NSLog(@"%@", dateString);
+    NSDate *releaseDate = [dateFormatter dateFromString:dateString];
+    return [self daysSinceDate:releaseDate];
 }
 
 #pragma mark - UIAlertActions

--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -87,6 +87,7 @@ NSString * const HarpyLanguageVietnamese            = @"vi";
         _alertType = HarpyAlertTypeOption;
         _lastVersionCheckPerformedOnDate = [[NSUserDefaults standardUserDefaults] objectForKey:HarpyDefaultStoredVersionCheckDate];
         _currentInstalledVersion = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+        _showAlertAfterCurrentVersionHasBeenReleasedForDays = 1;
     }
 
     return self;
@@ -175,12 +176,17 @@ NSString * const HarpyLanguageVietnamese            = @"vi";
             [[NSUserDefaults standardUserDefaults] setObject:[self lastVersionCheckPerformedOnDate] forKey:HarpyDefaultStoredVersionCheckDate];
             [[NSUserDefaults standardUserDefaults] synchronize];
 
+            NSDictionary<NSString *, id> *results = [self.appData valueForKey:@"results"];
+
+            NSString *releaseDate = [results valueForKey:@"currentVersionReleaseDate"];
+            
+
             /**
              Current version that has been uploaded to the AppStore.
              Used to contain all versions, but now only contains the latest version.
              Still returns an instance of NSArray.
              */
-            NSArray *versionsInAppStore = [[self.appData valueForKey:@"results"] valueForKey:@"version"];
+            NSArray *versionsInAppStore = [results valueForKey:@"version"];
 
             if ([versionsInAppStore count]) {
                 _currentAppStoreVersion = [versionsInAppStore objectAtIndex:0];

--- a/HarpyExample/HarpyExample/AppDelegate.m
+++ b/HarpyExample/HarpyExample/AppDelegate.m
@@ -27,6 +27,10 @@
     // (Optional) Set the Delegate to track what a user clicked on, or to use a custom UI to present your message.
     [[Harpy sharedInstance] setDelegate:self];
 
+    // (Optional) When this is set, the alert will only show up if the current version has already been released for X days.
+    /// By default, this value is set to 1 (day) to avoid an issue where Apple updates the JSON faster than the app binary propogates to the App Store.
+//    [[Harpy sharedInstance] setShowAlertAfterCurrentVersionHasBeenReleasedForDays:3];
+
     // (Optional) The tintColor for the alertController
 //    [[Harpy sharedInstance] setAlertControllerTintColor:[UIColor purpleColor]];
 


### PR DESCRIPTION
This PR introduces a new variable: `showAlertAfterCurrentVersionHasBeenReleasedForDays` with has a default value of 1 (day). The sole purpose of this feature is to allow for a delayed presentation of the update prompt. The value is set to 1 day by default to avoid a recent timing issue between the App Store JSON being updated faster than the App Store receiving your updated app binary.
