### PR TITLE
Removed a leftover debug NSLog

### DIFF
--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -456,7 +456,6 @@ NSString * const HarpyLanguageVietnamese            = @"vi";
 - (NSInteger)daysSinceDateString:(NSString *)dateString {
     NSDateFormatter *dateFormatter = [NSDateFormatter new];
     dateFormatter.dateFormat = @"yyyy-MM-dd'T'HH:mm:ss'Z'";
-    NSLog(@"%@", dateString);
     NSDate *releaseDate = [dateFormatter dateFromString:dateString];
     return [self daysSinceDate:releaseDate];
 }


### PR DESCRIPTION
Had a timestamp being printed whenever I start my app, it was driving me crazy, had no idea where its coming from.

Luckily, I figured the timestamp coincides with my last release, which was enough to figure where it was coming from. :)