### PR TITLE
Add support to customizing bundle id for apps with development builds

### DIFF
--- a/Harpy/Harpy.h
+++ b/Harpy/Harpy.h
@@ -107,6 +107,12 @@ typedef NS_ENUM(NSUInteger, HarpyAlertType)
 @property (nonatomic, assign, getter=isDebugEnabled) BOOL debugEnabled;
 
 /**
+ There are instances where there are different builds of the app used in development e.g Alpha and Beta builds. In order to accomodate this we allow overriding the bundle id only when debugging is enabled.
+ @b OPTIONAL: Specify a specific bundle id to be queried in the App Store. Applies only when @c debugEnabled is true.
+ */
+@property (nonatomic, assign) NSString *debugWithBundleID;
+
+/**
  @b OPTIONAL: The alert type to present to the user when there is an update. See the @c HarpyAlertType enum above.
  */
 @property (nonatomic, assign) HarpyAlertType alertType;

--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -442,6 +442,9 @@ NSString * const HarpyLanguageVietnamese            = @"vi";
 #pragma mark - NSBundle
 
 - (NSString *)bundleID {
+    if((self.debugEnabled) && (self.debugWithBundleID != nil)){
+        return self.debugWithBundleID;
+    }
     return [NSBundle mainBundle].bundleIdentifier;
 }
 

--- a/HarpyExample/HarpyExample/AppDelegate.m
+++ b/HarpyExample/HarpyExample/AppDelegate.m
@@ -51,6 +51,11 @@
 
     // Turn on Debug statements
     [[Harpy sharedInstance] setDebugEnabled:true];
+    
+    /* (Optional) The debugWithBundleID overrides the bundle id to be queried in the App Store
+        This only takes effect if debugEnabled is true.
+        For demo purposes, we used Twitter's bundle id -> com.atebits.Tweetie2 */
+//      [Harpy sharedInstance].debugWithBundleID = @"com.atebits.Tweetie2";
 
     // Perform check for new version of your app
     [[Harpy sharedInstance] checkVersion];


### PR DESCRIPTION
**Context:**
There are instances where we have Alpha or Beta builds during development which contains bundle ids that are not in the store. Given this setup, there must be a way to override the bundle id to enable testing. To keep it safe, the override mechanism only applies when `debugEnabled` is set to `true`. The property is named `debugWithBundleID` to insist that its for debugging.