### PR TITLE
Ability to reset skip version status.

### DIFF
--- a/Harpy/Harpy.h
+++ b/Harpy/Harpy.h
@@ -187,7 +187,7 @@ typedef NS_ENUM(NSUInteger, HarpyAlertType)
 - (void)checkVersionWeekly;
 
 /**
- Retset version skipped status
+ Reset version skipped status
  */
 - (void)resetSkipVersionStatus;
 

--- a/Harpy/Harpy.h
+++ b/Harpy/Harpy.h
@@ -186,6 +186,11 @@ typedef NS_ENUM(NSUInteger, HarpyAlertType)
  */
 - (void)checkVersionWeekly;
 
+/**
+ Retset version skipped status
+ */
+- (void)resetSkipVersionStatus;
+
 #pragma mark - Unit Testing
 
 /**

--- a/Harpy/Harpy.m
+++ b/Harpy/Harpy.m
@@ -151,6 +151,11 @@ NSString * const HarpyLanguageVietnamese            = @"vi";
     }
 }
 
+- (void)resetSkipVersionStatus {
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:HarpyDefaultSkippedVersion];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
 #pragma mark - Helpers
 
 - (void)performVersionCheck {


### PR DESCRIPTION
I wanted to use combination of Harpy and our own server controlled way of forcing user to update the app, and I needed to reset the skipped version status for it. There are a lot of other ways to go by this, like exposing alert method or writing our own method but I thought it would be a good addition to API. 